### PR TITLE
COMPATIBILITY: Resolve topic-bulk-actions deprecation

### DIFF
--- a/assets/javascripts/discourse/initializers/extend-for-tag-group-actions.js
+++ b/assets/javascripts/discourse/initializers/extend-for-tag-group-actions.js
@@ -1,7 +1,5 @@
-import { withPluginApi } from "discourse/lib/plugin-api";
 import SearchAdvancedOptions from "discourse/components/search-advanced-options";
-import { addBulkButton } from "discourse/controllers/topic-bulk-actions";
-import TopicButtonAction from "discourse/controllers/topic-bulk-actions";
+import { withPluginApi } from "discourse/lib/plugin-api";
 
 function initialize(api) {
   api.modifyClass("component:tag-group-chooser", {
@@ -17,6 +15,19 @@ function initialize(api) {
         }
       },
     },
+  });
+
+  api.addBulkActionButton({
+    label: "topics.bulk.close_deal",
+    icon: "user-plus",
+    class: "btn-default",
+    visible: ({ siteSettings }) =>
+      siteSettings.tga_bulk_action_tag_group_name &&
+      siteSettings.tga_bulk_action_replace_tag_name,
+    action({ performAndRefresh }) {
+      performAndRefresh({ type: "closeDeal" });
+    },
+    actionType: "performAndRefresh",
   });
 }
 
@@ -68,25 +79,6 @@ export default {
             REGEXP_TAG_GROUP_PREFIX
           );
         },
-      });
-    }
-
-    if (
-      currentUser &&
-      siteSettings.tga_bulk_action_tag_group_name &&
-      siteSettings.tga_bulk_action_replace_tag_name
-    ) {
-      TopicButtonAction.reopen({
-        actions: {
-          closeDeal() {
-            this.performAndRefresh({ type: "closeDeal" });
-          },
-        },
-      });
-
-      addBulkButton("closeDeal", "close_deal", {
-        icon: "user-plus",
-        class: "btn-default",
       });
     }
 


### PR DESCRIPTION
Meta: https://meta.discourse.org/t/fix-plugin-error-can-no-longer-import-topic-bulk-actions/316642

The PR fixes the deprecation around `topic-bulk-actions` using the `api.addBulkActionButton` API instead.

Before:
![image](https://github.com/user-attachments/assets/8460592e-bdfc-41a3-91f7-bb0770412d07)

After:
![NVIDIA_Share_t8GjUfnomG](https://github.com/user-attachments/assets/89d79769-1815-4863-bd47-b31370e01463)
